### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,11 +1,15 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: :index
+  before_action :authenticate_user!, except: [:index, :show]
 
   def index
+    @items = Item.all.order("created_at DESC")
   end
 
   def new
     @item = Item.new
+  end
+
+  def show
   end
 
   def create

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,6 +126,7 @@
     <%= link_to '新規投稿商品', new_item_path , class: "subtitle" %>
     <ul class='item-lists'>
 
+    <% if @items.exists?%> 
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to(item_path(item)) do %>
@@ -154,9 +155,8 @@
         <% end %>
       <% end %>
       </li>
-
+    <% else %>
       <%# 商品がない場合のダミー %>
-      <% unless Item.exists? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -173,8 +173,8 @@
           </div>
         </div>
         <% end %>
-      <% end %>
       </li>
+    <% end %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,6 @@
     <%= link_to '新規投稿商品', new_item_path , class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to(item_path(item)) do %>
@@ -155,10 +154,8 @@
         <% end %>
       <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% unless Item.exists? %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -178,7 +175,6 @@
         <% end %>
       <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,28 +123,29 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', new_item_path , class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to(item_path(item)) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れていればsold outを表示しましょう 
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outを表示しましょう %>
+          <% //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,11 +153,13 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless Item.exists? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -173,6 +176,7 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Item, type: :model do
     it 'カテゴリーの情報が必須であること(空の場合)' do
       @item.category_id = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Category can't be blank", "Category is not a number")
+      expect(@item.errors.full_messages).to include("Category can't be blank", 'Category is not a number')
     end
 
     it '商品の状態についての情報が必須であること' do
@@ -49,7 +49,7 @@ RSpec.describe Item, type: :model do
     it '商品の状態についての情報が必須であること(空の場合)' do
       @item.status_id = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Status can't be blank", "Status is not a number")
+      expect(@item.errors.full_messages).to include("Status can't be blank", 'Status is not a number')
     end
 
     it '配送料の負担についての情報が必須であること' do
@@ -61,7 +61,7 @@ RSpec.describe Item, type: :model do
     it '配送料の負担についての情報が必須であること(空の場合)' do
       @item.shipping_cost_id = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping cost can't be blank", "Shipping cost is not a number")
+      expect(@item.errors.full_messages).to include("Shipping cost can't be blank", 'Shipping cost is not a number')
     end
 
     it '発送元の地域についての情報が必須であること' do
@@ -73,7 +73,7 @@ RSpec.describe Item, type: :model do
     it '発送元の地域についての情報が必須であること(空の場合)' do
       @item.prefecture_id = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Prefecture can't be blank", "Prefecture is not a number")
+      expect(@item.errors.full_messages).to include("Prefecture can't be blank", 'Prefecture is not a number')
     end
 
     it '発送までの日数についての情報が必須であること' do
@@ -85,7 +85,7 @@ RSpec.describe Item, type: :model do
     it '発送までの日数についての情報が必須であること(空の場合)' do
       @item.shipping_date_id = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Shipping date can't be blank", "Shipping date is not a number")
+      expect(@item.errors.full_messages).to include("Shipping date can't be blank", 'Shipping date is not a number')
     end
 
     it '価格についての情報が必須であること' do


### PR DESCRIPTION
#What
商品一覧機能の実装

#Why
投稿された商品を閲覧できるようにするため

#URL
* 商品未登録時の表示：https://gyazo.com/668e3d1cbefa7118dbff5dc44ad0e8d1
* 商品登録時の挙動：https://gyazo.com/8296a2af3243346b3b22be77fb67790a
* 未ログインユーザーの商品詳細ページへの遷移：https://gyazo.com/77447b9e08729bb98475f40a8054d92a